### PR TITLE
Pouvoir générer une facture par commande

### DIFF
--- a/admin/ship2bill_setup.php
+++ b/admin/ship2bill_setup.php
@@ -49,7 +49,7 @@ if (preg_match('/set_(.*)/',$action,$reg))
 		dol_print_error($db);
 	}
 }
-	
+
 if (preg_match('/del_(.*)/',$action,$reg))
 {
 	$code=$reg[1];
@@ -128,16 +128,21 @@ print '<input type="submit" class="button" value="'.$langs->trans("Modify").'">'
 print '</form>';
 print '</td></tr>';
 
-// Create one invoice per shipment
+/* Select invoice management
+ * 0 => Une facture par tiers
+ * 1 => Une facture par expédition
+ * 2 => Une facture par commande
+ */
+$TBillingType = array(0 => $langs->trans('OneBillByThirdparty'), 1 => $langs->trans('OneBillByShipment'), 2 => $langs->trans('OneBillByOrder'));
 $var=!$var;
 print '<tr '.$bc[$var].'>';
-print '<td>'.$langs->trans("CreateOneInvoicePerShipment").'</td>';
+print '<td>'.$langs->trans("BillingManagement").'</td>';
 print '<td align="center" width="20">&nbsp;</td>';
-print '<td align="right" width="300">';
+print '<td align="right" width="320">';
 print '<form method="POST" action="'.$_SERVER['PHP_SELF'].'">';
 print '<input type="hidden" name="token" value="'.$_SESSION['newtoken'].'">';
 print '<input type="hidden" name="action" value="set_SHIP2BILL_INVOICE_PER_SHIPMENT">';
-print $form->selectyesno("SHIP2BILL_INVOICE_PER_SHIPMENT",$conf->global->SHIP2BILL_INVOICE_PER_SHIPMENT,1);
+print $form->selectarray("SHIP2BILL_INVOICE_PER_SHIPMENT", $TBillingType, $conf->global->SHIP2BILL_INVOICE_PER_SHIPMENT);
 print '<input type="submit" class="button" value="'.$langs->trans("Modify").'">';
 print '</form>';
 print '</td></tr>';
@@ -189,7 +194,7 @@ if($conf->global->SHIP2BILL_VALID_INVOICE && $conf->global->STOCK_CALCULATE_ON_B
 	// Define warehouse to use if stock movement is after invoice validation
 	dol_include_once('/product/class/html.formproduct.class.php');
 	$formproduct = new FormProduct($db);
-	
+
 	$var=!$var;
 	print '<tr '.$bc[$var].'>';
 	print '<td>'.$langs->trans("WarehouseToUseAfterInvoiceValidation").'</td>';

--- a/admin/ship2bill_setup.php
+++ b/admin/ship2bill_setup.php
@@ -38,8 +38,8 @@ if (preg_match('/set_(.*)/',$action,$reg))
 	if (dolibarr_set_const($db, $code, $codeValue, 'chaine', 0, '', $conf->entity) > 0)
     {
         if($code === 'SHIP2BILL_MULTIPLE_EXPED_ON_BILL_THIRDPARTY_CARD') {
-            if(!empty($codeValue)) setExtraVisibility($codeValue, 's2b_1bill_1shipment', 'societe');
-            else setExtraVisibility($codeValue, 's2b_1bill_1shipment', 'societe');
+            if(!empty($codeValue)) setExtraVisibility($codeValue, 's2b_bill_management', 'societe');
+            else setExtraVisibility($codeValue, 's2b_bill_management', 'societe');
         }
         header("Location: ".$_SERVER["PHP_SELF"]);
 		exit;

--- a/class/ship2bill.class.php
+++ b/class/ship2bill.class.php
@@ -79,7 +79,7 @@ class Ship2Bill {
 				// Chargement de l'expédition
 				$exp = new Expedition($db);
 				$exp->fetch($id_exp);
-				//Une facture par commande
+				//Une exped est forcément lié à une commande
 				$exp->fetchObjectLinked(0,'commande',$exp->id, 'shipping');
 				$fk_commande = reset($exp->linkedObjectsIds['commande']);
 

--- a/class/ship2bill.class.php
+++ b/class/ship2bill.class.php
@@ -1,16 +1,16 @@
 <?php
 
 class Ship2Bill {
-	
-	function generate_factures($TExpedition, $dateFact=0, $show_trace = true) 
+
+	function generate_factures($TExpedition, $dateFact=0, $show_trace = true)
 	{
 		global $conf, $langs, $db, $user;
-	
+		$TBilling = array();
 		// Inclusion des classes nécessaires
         dol_include_once('/commande/class/commande.class.php');
         dol_include_once('/compta/facture/class/facture.class.php');
         dol_include_once('/core/modules/facture/modules_facture.php');
-		
+
 		// Utilisation du module livraison
 		if($conf->livraison_bon->enabled) {
 			dol_include_once('/livraison/class/livraison.class.php');
@@ -22,22 +22,22 @@ class Ship2Bill {
 			$langs->load("subtotal@subtotal");
 			$sub = new ActionsSubtotal($db);
 		}
-		
+
 		// Option pour la génération PDF
 		$hidedetails = (! empty($conf->global->MAIN_GENERATE_DOCUMENTS_HIDE_DETAILS) ? 1 : 0);
 		$hidedesc = (! empty($conf->global->MAIN_GENERATE_DOCUMENTS_HIDE_DESC) ? 1 : 0);
 		$hideref = (! empty($conf->global->MAIN_GENERATE_DOCUMENTS_HIDE_REF) ? 1 : 0);
-		
+
 		if(empty($dateFact)) {
 			$dateFact = dol_now();
 		}
-		
+
 		$nbFacture = 0;
 		$TFiles = array();
-		
+
 		//unset les id expédition qui sont déjà liés à une facture
 		$this->_clearTExpedition($db, $TExpedition);
-		
+
 		// Pour chaque id client
 		foreach($TExpedition as $id_client => $Tid_exp)
 		{
@@ -51,34 +51,51 @@ class Ship2Bill {
 			if(!empty($conf->incoterm->enabled)) $incoterms_updated=false;
 
 			// Création d'une facture regroupant plusieurs expéditions (par défaut)
-			if(empty($conf->global->SHIP2BILL_INVOICE_PER_SHIPMENT) &&
-                (empty($conf->global->SHIP2BILL_MULTIPLE_EXPED_ON_BILL_THIRDPARTY_CARD) || (!empty($conf->global->SHIP2BILL_MULTIPLE_EXPED_ON_BILL_THIRDPARTY_CARD) && empty($soc->array_options['options_s2b_1bill_1shipment'])))
+			if(empty($conf->global->SHIP2BILL_INVOICE_PER_SHIPMENT) && (empty($conf->global->SHIP2BILL_MULTIPLE_EXPED_ON_BILL_THIRDPARTY_CARD)
+					|| (!empty($conf->global->SHIP2BILL_MULTIPLE_EXPED_ON_BILL_THIRDPARTY_CARD) && empty($soc->array_options['options_s2b_1bill_1shipment'])))
             ) {
 				$f = $this->facture_create($id_client, $dateFact);
 				$nbFacture++;
 			}
-			
+
 			// Pour chaque id expédition
 			foreach($Tid_exp as $id_exp => $val) {
-			
+
 				if($show_trace) echo $id_exp.'...';
-				
+
 				// Chargement de l'expédition
 				$exp = new Expedition($db);
 				$exp->fetch($id_exp);
-				
+				//Une facture par commande
+				if($conf->global->SHIP2BILL_INVOICE_PER_SHIPMENT == 2 && empty($conf->global->SHIP2BILL_MULTIPLE_EXPED_ON_BILL_THIRDPARTY_CARD)) {
+					$exp->fetchObjectLinked(0,'commande',$exp->id, 'shipping');
+					$fk_commande = reset($exp->linkedObjectsIds['commande']);
+				}
 				// Création d'une facture par expédition si option activée
-				if(!empty($conf->global->SHIP2BILL_INVOICE_PER_SHIPMENT) || ( !empty($conf->global->SHIP2BILL_MULTIPLE_EXPED_ON_BILL_THIRDPARTY_CARD) && !empty($soc->array_options['options_s2b_1bill_1shipment']))) {
+				/*
+				 * Si ce n'est pas géré par l'extrafield tiers => Si on a activé une facture par expédition OU une facture par commande mais qu'il n'y a pas encore de facture associé à la commande
+				 * Sinon on fait la même vérif mais avec l'extrafield
+				 */
+				if((empty($conf->global->SHIP2BILL_MULTIPLE_EXPED_ON_BILL_THIRDPARTY_CARD)
+						&& ($conf->global->SHIP2BILL_INVOICE_PER_SHIPMENT == 1 || ($conf->global->SHIP2BILL_INVOICE_PER_SHIPMENT == 2 && empty($TBilling[$fk_commande]))))
+					|| (!empty($conf->global->SHIP2BILL_MULTIPLE_EXPED_ON_BILL_THIRDPARTY_CARD) && !empty($soc->array_options['options_s2b_1bill_1shipment']))) {
 					$f = $this->facture_create($id_client, $dateFact);
 					$f->note_public = $exp->note_public;
 					$f->note_private = $exp->note_private;
 					$f->update($user);
 					$nbFacture++;
+					if(empty($conf->global->SHIP2BILL_MULTIPLE_EXPED_ON_BILL_THIRDPARTY_CARD) && $conf->global->SHIP2BILL_INVOICE_PER_SHIPMENT == 2){
+						$f->add_object_linked('commande', $fk_commande);
+						$TBilling[$fk_commande] = $f;
+					}
+				} else if(empty($conf->global->SHIP2BILL_MULTIPLE_EXPED_ON_BILL_THIRDPARTY_CARD) && $conf->global->SHIP2BILL_INVOICE_PER_SHIPMENT == 2 && !empty($TBilling[$fk_commande])) {
+					//Si une facture existe déjà pour la commande on l'a reprend
+					$f = $TBilling[$fk_commande];
 				}
-				
+
 				if(!empty($conf->incoterm->enabled) && !$incoterms_updated && !empty($exp->fk_incoterms)) {
 					$f->setIncoterms($exp->fk_incoterms, $exp->location_incoterms);
-					if(empty($conf->global->SHIP2BILL_INVOICE_PER_SHIPMENT)) $incoterms_updated=true;
+					if(empty($conf->global->SHIP2BILL_INVOICE_PER_SHIPMENT) || $conf->global->SHIP2BILL_INVOICE_PER_SHIPMENT == 2) $incoterms_updated=true;
 				}
 
 				// Ajout pour éviter déclenchement d'autres modules, par exemple ecotaxdee
@@ -102,14 +119,29 @@ class Ship2Bill {
 			if(count($Tid_exp) == 1) {
 				if (!empty($exp->note_public)) $f->update_note($exp->note_public, '_public');
 			}
-				
+
 			// Validation de la facture
-			if($conf->global->SHIP2BILL_VALID_INVOICE) $f->validate($user, '', $conf->global->SHIP2BILL_WARHOUSE_TO_USE);
-			if($show_trace){ echo $f->id.'|';flush(); }
-			// Génération du PDF
-			if(!empty($conf->global->SHIP2BILL_GENERATE_INVOICE_PDF)) $TFiles[] = $this->facture_generate_pdf($f, $hidedetails, $hidedesc, $hideref);
+			if(empty($conf->global->SHIP2BILL_MULTIPLE_EXPED_ON_BILL_THIRDPARTY_CARD) && $conf->global->SHIP2BILL_INVOICE_PER_SHIPMENT == 2) {
+				foreach($TBilling as $bill) {
+					if($conf->global->SHIP2BILL_VALID_INVOICE) $bill->validate($user, '', $conf->global->SHIP2BILL_WARHOUSE_TO_USE);
+					if($show_trace) {
+						echo $bill->id . '|';
+						flush();
+					}
+					// Génération du PDF
+					if(!empty($conf->global->SHIP2BILL_GENERATE_INVOICE_PDF)) $TFiles[] = $this->facture_generate_pdf($bill, $hidedetails, $hidedesc, $hideref);
+				}
+			} else {
+				if($conf->global->SHIP2BILL_VALID_INVOICE) $f->validate($user, '', $conf->global->SHIP2BILL_WARHOUSE_TO_USE);
+				if($show_trace) {
+					echo $f->id . '|';
+					flush();
+				}
+				// Génération du PDF
+				if(!empty($conf->global->SHIP2BILL_GENERATE_INVOICE_PDF)) $TFiles[] = $this->facture_generate_pdf($f, $hidedetails, $hidedesc, $hideref);
+			}
 		}
-		
+
 		if($conf->global->SHIP2BILL_GENERATE_GLOBAL_PDF) $this->generate_global_pdf($TFiles);
 
 		return $nbFacture;
@@ -118,42 +150,42 @@ class Ship2Bill {
 	function removeAllPDFFile() {
 		global $conf, $langs;
 		$dir = $conf->ship2bill->multidir_output[$conf->entity].'/';
-		
+
 		$TFile = dol_dir_list( $dir );
-			
+
 		$inputfile = array();
 		foreach($TFile as $file) {
-	
+
 			$ext = pathinfo($file['fullname'], PATHINFO_EXTENSION);
 			if($ext == 'pdf') {
 				$ret = dol_delete_file($file['fullname'], 0, 0, 0);
 			}
 		}
-	
-	
+
+
 	}
-	
+
 	function zipFiles() {
 		global $conf, $langs;
-	
+
 		if (defined('ODTPHP_PATHTOPCLZIP'))
 		{
-	
+
 			include_once ODTPHP_PATHTOPCLZIP.'/pclzip.lib.php';
-	
+
 			$dir = $conf->ship2bill->multidir_output[$conf->entity].'/';
-				
+
 			$file = 'archive_'.date('Ymdhis').'.zip';
-				
+
 			if(file_exists($file))	unlink($file);
-				
+
 			$archive = new PclZip($dir.$file);
-	
+
 			$TFile = dol_dir_list( $dir );
-				
+
 			$inputfile = array();
 			foreach($TFile as $file) {
-					
+
 				$ext = pathinfo($file['fullname'], PATHINFO_EXTENSION);
 				if($ext == 'pdf') {
 					$inputfile[] = $file['fullname'];
@@ -163,29 +195,29 @@ class Ship2Bill {
 				setEventMessage($langs->trans('NoFileInDirectory'),'warnings');
 				return;
 			}
-	
-	
+
+
 			$archive->add($inputfile, PCLZIP_OPT_REMOVE_PATH, $dir);
-	
+
 			setEventMessage($langs->trans('FilesArchived'));
-	
+
 			$this->removeAllPDFFile();
 		}
 		else {
-	
+
 			print "ERREUR : Librairie Zip non trouvée";
 		}
-	
+
 	}
-	
+
 	private function _clearTExpedition(&$db, &$TExpedition)
 	{
 		foreach($TExpedition as $id_client => &$Tid_exp)
 		{
-			foreach($Tid_exp as $id_exp => $val) 
+			foreach($Tid_exp as $id_exp => $val)
 			{
 				$sql = 'SELECT * FROM '.MAIN_DB_PREFIX.'element_element WHERE sourcetype="shipping" AND fk_source='.(int) $id_exp.' AND targettype="facture"';
-				
+
 				$resql = $db->query($sql);
 				if ($resql)
 				{
@@ -194,28 +226,28 @@ class Ship2Bill {
 						unset($Tid_exp[$id_exp]);
 					}
 				}
-				
+
 			}
-			
+
 		}
 	}
 
 	function facture_create($id_client, $dateFact) {
 		global $user, $db, $conf;
-		
+
 		$f = new Facture($db);
 
-		// Si le module Client facturé est activé et que la constante BILLANOTHERCUSTOMER_USE_PARENT_BY_DEFAULT est à 1, on facture la maison mère 
+		// Si le module Client facturé est activé et que la constante BILLANOTHERCUSTOMER_USE_PARENT_BY_DEFAULT est à 1, on facture la maison mère
 		if($conf->billanothercustomer->enabled && $conf->global->BILLANOTHERCUSTOMER_USE_PARENT_BY_DEFAULT) {
 			$soc = new Societe($db);
 			$soc->fetch($id_client);
 			if($soc->parent > 0)
 				$id_client = $soc->parent;
 		}
-		
+
 		$f->socid = $id_client;
 		$f->fetch_thirdparty();
-		
+
 		// Données obligatoires
 		$f->date = $dateFact;
 		$f->type = 0;
@@ -226,13 +258,13 @@ class Ship2Bill {
 		$f->mode_reglement_id = $f->thirdparty->mode_reglement_id;
 		$f->modelpdf = !empty($conf->global->SHIP2BILL_GENERATE_INVOICE_PDF) ? $conf->global->SHIP2BILL_GENERATE_INVOICE_PDF : 'crabe';
 		$f->statut = 0;
-		
+
 		//Récupération du compte bancaire si mode de règlement = VIR
 		if (!empty($conf->global->SHIP2BILL_USE_DEFAULT_BANK_IN_INVOICE_MODULE) && !empty($conf->global->FACTURE_RIB_NUMBER) && $this->getModeReglementCode($db , $f->mode_reglement_id) == 'VIR')
 		{
 			$f->fk_account = $conf->global->FACTURE_RIB_NUMBER;
 		}
-		
+
 		$f->create($user);
 
 		if(empty($f->fk_account) && !empty($f->thirdparty->fk_account)) $f->setBankAccount($f->thirdparty->fk_account);
@@ -243,18 +275,18 @@ class Ship2Bill {
 	function getModeReglementCode(&$db, $mode_reglement_id)
 	{
 		if ($mode_reglement_id <= 0) return '';
-		
+
 		$code = '';
 		$sql = 'SELECT code FROM '.MAIN_DB_PREFIX.'c_paiement WHERE id = '.(int) $mode_reglement_id;
 		$resql = $db->query($sql);
 		if ($resql && ($row = $db->fetch_object($resql))) $code = $row->code;
-		
+
 		return $code;
 	}
-	
+
 	function facture_add_line(&$f, &$exp) {
 		global $conf, $db;
-		
+
 		// Pour chaque produit de l'expédition, ajout d'une ligne de facture
 		foreach($exp->lines as $l){
 			if($conf->global->SHIPMENT_GETS_ALL_ORDER_PRODUCTS && $l->qty == 0) continue;
@@ -263,24 +295,24 @@ class Ship2Bill {
 				$orderline = new OrderLine($db);
 				$orderline->fetch($l->fk_origin_line);
 				$orderline->fetch_optionals();
-				
+
 				// Si ligne du module sous-total et que sa description est vide alors il faut attribuer le label (le label ne semble pas être utiliser pour l'affichage car deprécié)
 				if (!empty($conf->subtotal->enabled) && $orderline->special_code == TSubtotal::$module_number && empty($l->description)) $l->description = $l->label;
-				
+
 				if((float)DOL_VERSION <= 3.4)
 					$f->addline($f->id, $l->description, $l->subprice, $l->qty, $l->tva_tx,$l->localtax1tx,$l->localtax2tx,$l->fk_product, $l->remise_percent,'','',0,0,'','HT',0,0,-1,0,'shipping',$l->line_id,0,$orderline->fk_fournprice,$orderline->pa_ht,$orderline->label);
 				else
 					$f->addline($l->description, $l->subprice, $l->qty, $l->tva_tx,$l->localtax1tx,$l->localtax2tx,$l->fk_product, $l->remise_percent,'','',0,0,'','HT',0,$orderline->product_type,-1,$orderline->special_code,'shipping',$l->line_id,0,$orderline->fk_fournprice,$orderline->pa_ht,$orderline->label, $orderline->array_options);
 			}
 		}
-		
+
 		//Récupération des services de la commande si SHIP2BILL_GET_SERVICES_FROM_ORDER
 		if($conf->global->SHIP2BILL_GET_SERVICES_FROM_ORDER && (float)DOL_VERSION >= 3.5 && empty($conf->global->STOCK_SUPPORTS_SERVICES)){
 			dol_include_once('/commande/class/commande.class.php');
-			
+
 			$commande = new Commande($db);
 			$commande->fetch($exp->origin_id);
-			
+
 			//pre($commande->linkedObjects,true);exit;
 			if($this->_expeditionBilled($commande)) {
 				null;
@@ -288,12 +320,12 @@ class Ship2Bill {
 			else{
 
 				foreach($commande->lines as $line){
-	
+
 					//Prise en compte des services et des lignes libre uniquement
 					if($line->fk_product_type == 1 || (empty($line->fk_product_type) && empty($line->fk_product))){
-						
+
 						//echo $exp->id;exit;
-						
+
 						$f->addline(
 								$line->desc,
 								$line->price,
@@ -321,34 +353,34 @@ class Ship2Bill {
 						);
 					}
 				}
-				
+
 			}
-			
+
 		}
 	}
-	
+
 	//On regarde si une commande a déjà été facturée : si oui alors les services ont déjà été facturée
 	function _expeditionBilled(&$commande){
 		$commande->fetchObjectLinked($exp->origin_id, 'commande', '', 'shipping');
 
 		foreach($commande->linkedObjects['shipping'] as $expedition){
-			
+
 			$expedition->fetchObjectLinked($expedition->id,'shipping','','facture');
-			
+
 			if(count($expedition->linkedObjects['facture']) > 0) return true;
 		}
-		
+
 		return false;
 	}
-	
+
 	function facture_add_title (&$f, &$exp, &$sub) {
 		global $conf, $langs, $db;
-		
+
 		// Affichage des références expéditions en tant que titre
 		if($conf->global->SHIP2BILL_ADD_SHIPMENT_AS_TITLES) {
 			$title = '';
 			$exp->fetchObjectLinked('','commande');
-			
+
 			// Récupération des infos de la commande pour le titre
 			if (! empty($exp->linkedObjectsIds['commande'])) {
 				$id_ord = array_pop($exp->linkedObjectsIds['commande']);
@@ -358,12 +390,12 @@ class Ship2Bill {
 				if(!empty($ord->ref_client)) $title.= ' / '.$ord->ref_client;
 				if(!empty($ord->date_commande)) $title.= ' ('.dol_print_date($ord->date_commande,'day').')';
 			}
-			
+
 			$title2 = $langs->transnoentities('Shipment').' '.$exp->ref;
 			if(!empty($exp->date_delivery)) $title2.= ' ('.dol_print_date($exp->date_delivery,'day').')';
 			if($conf->livraison_bon->enabled) {
 				$exp->fetchObjectLinked('','','','delivery');
-				
+
 				// Récupération des infos du BL pour le titre, sinon de l'expédition
 				if (! empty($exp->linkedObjectsIds['delivery'])) {
 					$id_liv = array_pop($exp->linkedObjectsIds['delivery']);
@@ -373,13 +405,13 @@ class Ship2Bill {
 					if(!empty($liv->date_delivery)) $title2.= ' ('.dol_print_date($liv->date_delivery,'day').')';
 				}
 			}
-			
+
 			$title.= ' - '.$title2;
-			
+
 			if($ord->socid > 0 && $conf->global->SHIP2BILL_DISPLAY_ORDERCUSTOMER_IN_TITLE) {
 				$soc = new Societe($db);
 				$soc->fetch($ord->socid);
-				
+
 				$title.= ' - '.$soc->name.' '.$soc->zip.' '.$soc->town;
 			}
 			//exit($title);
@@ -399,7 +431,7 @@ class Ship2Bill {
 
 	function facture_add_subtotal(&$f,&$sub) {
 		global $conf, $langs;
-		
+
 		// Ajout d'un sous-total par expédition
 		if($conf->global->SHIP2BILL_ADD_SHIPMENT_SUBTOTAL) {
 			if($conf->subtotal->enabled) {
@@ -434,36 +466,36 @@ class Ship2Bill {
 
 	function facture_generate_pdf(&$f, $hidedetails, $hidedesc, $hideref) {
 		global $conf, $langs, $db;
-		
+
 		// Il faut recharger les lignes qui viennent juste d'être créées
 		$f->fetch($f->id);
-		
+
 		$outputlangs = $langs;
 		if ($conf->global->MAIN_MULTILANGS) {$newlang=$f->client->default_lang;}
 		if (! empty($newlang)) {
 			$outputlangs = new Translate("",$conf);
 			$outputlangs->setDefaultLang($newlang);
 		}
-		
+
 		if ((float) DOL_VERSION <= 4.0)	$result=facture_pdf_create($db, $f, $f->modelpdf, $outputlangs, $hidedetails, $hidedesc, $hideref);
 		else $result = $f->generateDocument($f->modelpdf, $outputlangs, $hidedetails, $hidedesc, $hideref);
-		
+
 		if($result > 0) {
 			$objectref = dol_sanitizeFileName($f->ref);
 			$dir = $conf->facture->dir_output . "/" . $objectref;
 			$file = $dir . "/" . $objectref . ".pdf";
 			return $file;
 		}
-		
+
 		return '';
 	}
 
-	function generate_global_pdf($TFiles) 
+	function generate_global_pdf($TFiles)
 	{
 		global $langs, $conf;
-		
+
 		dol_include_once('/core/lib/pdf.lib.php');
-		
+
         // Create empty PDF
         $pdf=pdf_getInstance();
         if (class_exists('TCPDF'))

--- a/config.php
+++ b/config.php
@@ -1,7 +1,35 @@
 <?php
-		
+
 	if(is_file('../main.inc.php'))$dir = '../';
 	else  if(is_file('../../../main.inc.php'))$dir = '../../../';
 	else $dir = '../../';
 
 	include($dir."main.inc.php");
+
+if(!defined('INC_FROM_CRON_SCRIPT') && !defined('INC_FROM_DOLIBARR')) {
+
+	if(!class_exists('modShip2bill')) dol_include_once('/ship2bill/core/modules/modShip2bill.class.php');
+	checkVersion($db, 'modShip2bill');
+
+}
+
+function checkVersion(&$DoliDb, $moduleName) {
+	global $conf;
+	if(class_exists($moduleName)) {
+
+		$conf_name = 'ATM_MODULE_VERSION_'.strtoupper($moduleName);
+
+		$mod = new $moduleName($DoliDb);
+
+		if(!empty($mod->version)) {
+			$version = $mod->version;
+			if($conf->global->$conf_name != $version) {
+
+				$message = "Your module wasn't updated (v".$conf->global->$conf_name." != ".$version."). Please reload it or launch the update of database script";
+
+				accessforbidden($message);
+			}
+		}
+	}
+
+}

--- a/config.php
+++ b/config.php
@@ -13,6 +13,7 @@ if(!defined('INC_FROM_CRON_SCRIPT') && !defined('INC_FROM_DOLIBARR')) {
 
 }
 
+//Fonction reprise d'abricot, car module fonctionnant sans abricot
 function checkVersion(&$DoliDb, $moduleName) {
 	global $conf;
 	if(class_exists($moduleName)) {

--- a/core/modules/modShip2bill.class.php
+++ b/core/modules/modShip2bill.class.php
@@ -55,7 +55,7 @@ class modShip2bill extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Module permettant de regrouper plusieurs expéditions en une seule facture";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '2.0.0';
+		$this->version = '1.6.0';
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)
@@ -233,24 +233,10 @@ class modShip2bill extends DolibarrModules
 
         // extrafields tiers
         $res = $extrafields->addExtraField('s2b_bill_management', 'Regroupement des expéditions dans une facture lors de la génération en masse', 'select', 0, 0, 'thirdparty', 0, 0, '',  array('options'=>array(1 => 'Une facture par tiers', 2=> 'Une facture par expédition', 3=>'Une facture par commande')), 1, '',  $conf->global->SHIP2BILL_MULTIPLE_EXPED_ON_BILL_THIRDPARTY_CARD);
-		$this->checkVersion();
+		$this->updateS2b_bill_management($this->db);
+
+		$this->setVersion($this->db, 'modShip2bill');
 		return $this->_init($sql, $options);
-	}
-
-	function checkVersion() {
-		global $db;
-
-		$sql = "SELECT value FROM" . MAIN_DB_PREFIX . "const WHERE name='ATM_MODULE_VERSION_MODSHIP2BILL'";
-		$resql = $db->query($sql);
-		if(!empty($resql) && $db->num_rows($resql) > 0) {
-			$obj = $db->fetch_object($resql);
-			if(substr($this->version, 0, 1) >= 2 && substr($obj->value, 0, 1) < 2) $this->updateS2b_bill_management($db);
-		}
-		else { //Sinon ça veut dire qu'on est dans une version pour laquelle la const version n'existe pas (<=1.5)
-			$this->updateS2b_bill_management($db);
-		}
-
-		$this->setVersion($db, 'modShip2bill');
 	}
 
 	function updateS2b_bill_management(DoliDB $db) {

--- a/core/modules/modShip2bill.class.php
+++ b/core/modules/modShip2bill.class.php
@@ -179,7 +179,7 @@ class modShip2bill extends DolibarrModules
 		$r=0;
 
 		$langs->load('ship2bill@ship2bill');
-		
+
 		$this->menu[$r]=array(	'fk_menu'=>'fk_mainmenu=products,fk_leftmenu=sendings',		    // Use 'fk_mainmenu=xxx' or 'fk_mainmenu=xxx,fk_leftmenu=yyy' where xxx is mainmenucode and yyy is a leftmenucode
 								'type'=>'left',			                // This is a Left menu entry
 								'titre'=>$langs->trans('Ship2BillMenu'),
@@ -222,6 +222,7 @@ class modShip2bill extends DolibarrModules
 	 */
 	function init($options='')
 	{
+		global $conf;
 		$sql = array();
 
 		$result=$this->_load_tables('/ship2bill/sql/');
@@ -232,7 +233,7 @@ class modShip2bill extends DolibarrModules
 
         // extrafields tiers
         $res = $extrafields->addExtraField('s2b_1bill_1shipment', 'Ne pas regrouper plusieurs expéditions dans une facture lors de la génération en masse', 'boolean', 0, 0, 'thirdparty', 0, 0, '', '', 1, '', 0);
-
+        $res = $extrafields->update('s2b_1bill_1shipment', 'Regroupement des expéditions dans une facture lors de la génération en masse', 'select', 0,  'thirdparty', 0, 0, 0, array('options'=>array(0 => 'Une facture par tiers', 1=> 'Une facture par expédition', 2=>'Une facture par commande')), 1, '', $conf->global->SHIP2BILL_MULTIPLE_EXPED_ON_BILL_THIRDPARTY_CARD,'','0');
 		return $this->_init($sql, $options);
 	}
 

--- a/langs/fr_FR/ship2bill.lang
+++ b/langs/fr_FR/ship2bill.lang
@@ -36,3 +36,8 @@ Stateshipment=État expédition
 SHIP2BILL_LIST_LENGTH=Nombre d'expéditions à afficher dans la liste des expéditions facturables <br> (laisser vide pour utiliser la configuration de dolibarr)
 
 SHIP2BILL_MULTIPLE_EXPED_ON_BILL_THIRDPARTY_CARD=La facturation des expéditions multiples est géré sur la fiche du tiers
+
+OneBillByThirdparty=Une facture par tiers
+OneBillByShipment=Une facture par expédition
+OneBillByOrder=Une facture par commande
+BillingManagement=Gestion de la facturation


### PR DESCRIPTION
Probablement une V2 suite à cette évo : 

- Modification de la conf en select afin de pouvoir choisir entre les 3 options : 1 facture par tiers, par commande, par expedition

- Modification de l'extrafield tiers existant, conversion en select + migration de l'extrafield en fonction de la version du module (si existant)

- Si la gestion par extrafield tiers est activé : si extrafield vide on reprend la conf du module, sinon on prend la conf de l'extrafield

- Refactoring des conditions

- Liaison de la commande à la facture

Hésitez pas à me dire si vous trouvez le checkVersion du config.php trop extrème (en gros si le num du module est différent de celui stocké en base, on oblige à désactiver réactiver le module)
