### PR TITLE
FIX : missing GETPOST check parameters (none)

### DIFF
--- a/admin/ship2bill_setup.php
+++ b/admin/ship2bill_setup.php
@@ -13,8 +13,8 @@ global $db;
 // Security check
 if (! $user->admin) accessforbidden();
 
-$action=GETPOST('action');
-$id=GETPOST('id');
+$action=GETPOST('action', 'alpha');
+$id=GETPOST('id', 'int');
 
 /*
  * Action
@@ -34,7 +34,7 @@ if($action == 'set_SHIP2BILL_LIST_LENGTH'){
 if (preg_match('/set_(.*)/',$action,$reg))
 {
 	$code=$reg[1];
-    $codeValue = GETPOST($code);
+    $codeValue = GETPOST($code, 'none');
 	if (dolibarr_set_const($db, $code, $codeValue, 'chaine', 0, '', $conf->entity) > 0)
     {
         if($code === 'SHIP2BILL_MULTIPLE_EXPED_ON_BILL_THIRDPARTY_CARD') {

--- a/ship2bill.php
+++ b/ship2bill.php
@@ -46,16 +46,16 @@ $result = restrictedArea($user, 'expedition');
 $hookmanager->initHooks(array('invoicecard'));
 
 $action = GETPOST('action','alpha');
-$search_ref_exp = GETPOST("search_ref_exp");
-$search_start_delivery_date = GETPOST('search_start_delivery_date');
-$search_end_delivery_date = GETPOST('search_end_delivery_date');
+$search_ref_exp = GETPOST("search_ref_exp", 'none');
+$search_start_delivery_date = GETPOST('search_start_delivery_date', 'none');
+$search_end_delivery_date = GETPOST('search_end_delivery_date', 'none');
 if(!empty($search_start_delivery_date))$tmp_date_start = str_replace('/', '-', $search_start_delivery_date);
 if(!empty($search_end_delivery_date))$tmp_date_end = str_replace('/', '-', $search_end_delivery_date);
-$search_ref_client = GETPOST("search_ref_client");
-$search_ref_cde = GETPOST("search_ref_cde");
-$search_ref_liv = GETPOST('search_ref_liv');
-$search_societe = GETPOST("search_societe");
-$search_status = GETPOST("search_status");
+$search_ref_client = GETPOST("search_ref_client", 'none');
+$search_ref_cde = GETPOST("search_ref_cde", 'none');
+$search_ref_liv = GETPOST('search_ref_liv', 'none');
+$search_societe = GETPOST("search_societe", 'none');
+$search_status = GETPOST("search_status", 'int');
 $search_order_statut=GETPOST('search_order_statut','int');
 
 $sortfield = GETPOST('sortfield','alpha');
@@ -76,17 +76,17 @@ if (! $sortorder) $sortorder="DESC";
 $limit = $conf->liste_limit;
 
 
-$confirm = GETPOST('confirm');
+$confirm = GETPOST('confirm', 'none');
 $formconfirm = '';
 $form=new Form($db);
 
 if(isset($_REQUEST['subCreateBill'])){
 	$TExpedition = $_REQUEST['TExpedition'];
-	$dateFact = GETPOST('dtfact');
+	$dateFact = GETPOST('dtfact', 'int');
 	if(empty($dateFact)) {
 		$dateFact = dol_now();
 	} else {
-		$dateFact = dol_mktime(0, 0, 0, GETPOST('dtfactmonth'), GETPOST('dtfactday'), GETPOST('dtfactyear'));
+		$dateFact = dol_mktime(0, 0, 0, GETPOST('dtfactmonth', 'int'), GETPOST('dtfactday', 'int'), GETPOST('dtfactyear', 'int'));
 	}
 	if(empty($TExpedition)) {
 		setEventMessage($langs->trans('NoShipmentSelected'), 'warnings');
@@ -109,10 +109,10 @@ if ($action == 'remove_file')
 
 	$langs->load("other");
 	$upload_dir = $diroutputpdf;
-	$file = $upload_dir . '/' . GETPOST('file');
+	$file = $upload_dir . '/' . GETPOST('file', 'alpha' );
 	$ret=dol_delete_file($file,0,0,0,'');
-	if ($ret) setEventMessage($langs->trans("FileWasRemoved", GETPOST('urlfile')));
-	else setEventMessage($langs->trans("ErrorFailToDeleteFile", GETPOST('urlfile')), 'errors');
+	if ($ret) setEventMessage($langs->trans("FileWasRemoved", GETPOST('urlfile', 'alpha')));
+	else setEventMessage($langs->trans("ErrorFailToDeleteFile", GETPOST('urlfile', 'alpha')), 'errors');
 	$action='';
 }
 else if($action=='delete_all_pdf_files') {
@@ -146,7 +146,7 @@ else if($action=='confirm_archive_files' && $confirm == 'yes') {
 
 
 // Do we click on purge search criteria ?
-if (GETPOST("button_removefilter_x"))
+if (GETPOST("button_removefilter_x", 'none'))
 {
 
     $search_ref_exp='';


### PR DESCRIPTION
# FIX

A partir de la v12 le paramètre check de la fonction GETPOST est alphanohtml par défaut ce qui fait que tous nos inputs ayant une balise html sont vidés.

Modification (et typage) de tous les paramètres check manquants.