### PR TITLE
Add shipment extrafields on invoice + Changelog

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,0 +1,7 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+
+## UNRELEASED
+
+- NEW Add shipment extrafields values on the created invoice [2021-02-11]
+- NEW Add shipment origin (order) as a linked object of the invoice [2021-02-11]

--- a/class/ship2bill.class.php
+++ b/class/ship2bill.class.php
@@ -92,6 +92,7 @@ class Ship2Bill {
 					$f = $this->facture_create($id_client, $dateFact);
 					$f->note_public = $exp->note_public;
 					$f->note_private = $exp->note_private;
+					$f->array_options = $exp->array_options;
 					$f->update($user);
 					$nbFacture++;
 				} else if(($conditionForBillByOrder) && !empty($TBilling[$fk_commande])) {
@@ -117,6 +118,7 @@ class Ship2Bill {
 				// Lien avec la facture
 				$f->add_object_linked('shipping', $exp->id);
 				$f->add_object_linked('commande', $fk_commande);
+				$f->add_object_linked($exp->origin, $exp->origin_id);
 				// Ajout des contacts facturation provenant de l'expé
 				$this->facture_add_shipping_contacts($f, $exp);
 				// Clôture de l'expédition

--- a/core/modules/modShip2bill.class.php
+++ b/core/modules/modShip2bill.class.php
@@ -54,6 +54,8 @@ class modShip2bill extends DolibarrModules
 		$this->name = preg_replace('/^mod/i','',get_class($this));
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Module permettant de regrouper plusieurs expéditions en une seule facture";
+		$this->editor_name = 'ATM Consulting';
+		$this->editor_url = 'https://www.atm-consulting.fr';
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
 		$this->version = '1.6.0';
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)

--- a/core/modules/modShip2bill.class.php
+++ b/core/modules/modShip2bill.class.php
@@ -57,7 +57,7 @@ class modShip2bill extends DolibarrModules
 		$this->editor_name = 'ATM Consulting';
 		$this->editor_url = 'https://www.atm-consulting.fr';
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '1.6.0';
+		$this->version = '1.7.0';
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)


### PR DESCRIPTION
**Please make a release of this feature for Dolistore**

On invoice creation, retrieve the shipment extrafields
Add the order as a linked object