### PR TITLE
FIX 1.7 comply with dolistore rules + version comparator: compare only X.Y

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## 1.7
+- FIX: compliance with dolistore rules for `main.inc.php` inclusion - *2021-10-20* - 1.7.2
 - FIX: incomplete v13 compatibility - *2021-10-07* - 1.7.1
 - NEW: Add shipment extrafields values on the created invoice - *2021-02-11* - 1.7.0
 - NEW: Add shipment origin (order) as a linked object of the invoice - *2021-02-11* - 1.7.0

--- a/config.php
+++ b/config.php
@@ -1,10 +1,18 @@
 <?php
-
-	if(is_file('../main.inc.php'))$dir = '../';
-	else  if(is_file('../../../main.inc.php'))$dir = '../../../';
-	else $dir = '../../';
-
-	include($dir."main.inc.php");
+$res = 0;
+// Try main.inc.php using relative path
+if (!$res && file_exists("../main.inc.php")) {
+	$res = @include __DIR__ . "/../main.inc.php";
+}
+if (!$res && file_exists("../../main.inc.php")) {
+	$res = @include __DIR__ . "/../../main.inc.php";
+}
+if (!$res && file_exists("../../../main.inc.php")) {
+	$res = @include __DIR__ . "/../../../main.inc.php";
+}
+if (!$res) {
+	die("Include of main fails");
+}
 
 if(!defined('INC_FROM_CRON_SCRIPT') && !defined('INC_FROM_DOLIBARR')) {
 
@@ -14,6 +22,10 @@ if(!defined('INC_FROM_CRON_SCRIPT') && !defined('INC_FROM_DOLIBARR')) {
 }
 
 //Fonction reprise d'abricot, car module fonctionnant sans abricot
+/**
+ * @param DoliDB $DoliDb
+ * @param string $moduleName
+ */
 function checkVersion(&$DoliDb, $moduleName) {
 	global $conf;
 	if(class_exists($moduleName)) {
@@ -24,7 +36,7 @@ function checkVersion(&$DoliDb, $moduleName) {
 
 		if(!empty($mod->version)) {
 			$version = $mod->version;
-			if($conf->global->$conf_name != $version) {
+			if(versionXY($conf->global->$conf_name) != versionXY($version)) {
 
 				$message = "Your module wasn't updated (v".$conf->global->$conf_name." != ".$version."). Please reload it or launch the update of database script";
 
@@ -33,4 +45,13 @@ function checkVersion(&$DoliDb, $moduleName) {
 		}
 	}
 
+}
+
+/**
+ * @param string $version  A version number in the form X.Y.Z (ex: 1.21.9)
+ *
+ * @return string  The same version number with only X.Y (ex: 1.21)
+ */
+function versionXY($version) {
+	return preg_replace('/^(\d+\.\d+)(\.\d+)?$/', '$1', $version);
 }

--- a/core/modules/modShip2bill.class.php
+++ b/core/modules/modShip2bill.class.php
@@ -57,7 +57,7 @@ class modShip2bill extends DolibarrModules
 		$this->editor_name = 'ATM Consulting';
 		$this->editor_url = 'https://www.atm-consulting.fr';
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '1.7.1';
+		$this->version = '1.7.2';
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)


### PR DESCRIPTION
# FIX
Le zip du module est rejeté par Dolistore car la façon d’inclure `main.inc.php` ne correspond pas à ce qui est attendu.

Autre souci corrigé au passage: le module a une feature sympa d'auto-détection des changements de version, mais il compare même les versions mineures (autrement dit, il t'oblige à le redémarrer pour passer de la 1.7.1 à la 1.7.2).